### PR TITLE
fix build warning

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=  -O3 -I../include  -g -Wno-format
+CFLAGS=  -Wall -Werror -O3 -I../include -g -Wno-format
 OBJECTS= hello_mutex.o lockdep.o
 LIBS = -lpthread
 

--- a/lib/lockdep.c
+++ b/lib/lockdep.c
@@ -222,7 +222,6 @@ dump_lockdep(int dmpbt)
 static int
 will_lock(pthread_mutex_t *mutex, int pid)
 {
-	unsigned long	sp;
 	int	lockid, i;
 	Btrace	*bt;
 


### PR DESCRIPTION
```
lib: fix ../lib/lockdep.c:225:16: error: unused variable 'sp' [-Werror,-Wunused-variable]

gcc -Wall -Werror -O3 -I../include -g -Wno-format -c hello_mutex.c
gcc -Wall -Werror -O3 -I../include -g -Wno-format -c ../lib/lockdep.c
../lib/lockdep.c:225:16: error: unused variable 'sp' [-Werror,-Wunused-variable]
        unsigned long   sp;
                        ^
1 error generated.
make: *** [lockdep.o] Error 1
make: *** Waiting for unfinished jobs....
```
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>