### PR TITLE
fix  ../lib/lockdep.c:215:29: error: array subscript is of type 'char…

### DIFF
--- a/lib/lockdep.c
+++ b/lib/lockdep.c
@@ -209,7 +209,7 @@ dump_lockdep(int dmpbt)
 #ifdef DEBUG
 				if(dmpbt == 1) {
 					char **strings = backtrace_symbols((void *const *)bt->payload, BACKTRACE_LOG_DEPTH);
-					for (char k = 0; k < BACKTRACE_LOG_DEPTH; k++)
+					for (int k = 0; k < BACKTRACE_LOG_DEPTH; k++)
 						printf("%s\n", strings[k]);
 				}
 #endif


### PR DESCRIPTION
fix  ../lib/lockdep.c:215:29: error: array subscript is of type 'char'[-Werror,-Wchar-subscripts]

````
➜  /Users/junbozheng/my/lockdep/example [25-10-25_18:11:43] git:(master) ✗ make
gcc -Wall -Werror -O3 -I../include -g -Wno-format -c ../lib/lockdep.c
../lib/lockdep.c:215:29: error: array subscript is of type 'char' [-Werror,-Wchar-subscripts]
  215 |                                                 printf("%s\n", strings[k]);
      |                                                                       ^~
1 error generated.
make: *** [lockdep.o] Error 1
````

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>