### PR TITLE
example: add `-DDEBUG` macro to CFLAGS

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,8 +1,7 @@
 CC=gcc
-CFLAGS=  -Wall -Werror -O3 -I../include -g -Wno-format
+CFLAGS=  -Wall -Werror -O3 -I../include -g -Wno-format -DDEBUG
 OBJECTS= hello_mutex.o lockdep.o
 LIBS = -lpthread
-
 
 # --- targets
 all:    lockdep_test


### PR DESCRIPTION
example: add `-DDEBUG` macro to CFLAGS

Build and Test
```c
➜  /Users/junbozheng/xiaomi/lockdep/example [25-12-30_22:48:41] git:(debug) make clean
rm -f lockdep_test hello_mutex.o lockdep.o
➜  /Users/junbozheng/xiaomi/lockdep/example [25-12-30_22:48:44] git:(debug) make      
gcc -Wall -Werror -O3 -I../include -g -Wno-format -DDEBUG -c hello_mutex.c
gcc -Wall -Werror -O3 -I../include -g -Wno-format -DDEBUG -c ../lib/lockdep.c
gcc -Wall -Werror -O3 -I../include -g -Wno-format -DDEBUG -o lockdep_test  hello_mutex.o lockdep.o -lpthread
➜  /Users/junbozheng/xiaomi/lockdep/example [25-12-30_22:48:48] git:(debug) ./lockdep_test 
task A! It's me, thread #0!
lockdep_init <<< 
task B! It's me, thread #1!
lockdep_init <<< 
lockdep_init >>> 
will_lock >>>
will_lock <<<
locked >>> 
locked <<< 
lockdep_init >>> 
will_lock >>>
will_lock <<<
locked >>> 
locked <<< 
will_lock >>>
will_lock <<<
will_lock >>>
will_lock <<<
^C
➜  /Users/junbozheng/xiaomi/lockdep/example [25-12-30_22:48:55] git:(debug) 
```